### PR TITLE
Develop/instruction defs without vector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,13 @@ before time is spent on code.
 
 Contributions which add new features or result in large changes to the codebase should be discussed by the community
 [in an issue](https://github.com/push-language/Puj/issues) before being implemented. Once an issue has been fully
-discussed it will be considered ready for a [pul request](https://github.com/push-language/Puj/pulls).
+discussed it will be considered ready for a [pull request](https://github.com/push-language/Puj/pulls).
 
 ## Workflow for contributions
 
 1. Fork the repository
 2. Create a feature branch (aka topic branch) for your changes.
-3. Add you code changes.
+3. Add your code changes.
     - Be sure to add adequate tests and documentation for your change, if applicable.
     - Contributions which use a sane code style will be appreciated. :)
 4. Ensure all tests are passing.

--- a/src/puj/push/instructions/numeric.clj
+++ b/src/puj/push/instructions/numeric.clj
@@ -8,30 +8,24 @@
    (with-meta
      (u/->SimpleInstruction
        [:int :int]          ; Takes two arguments from the :int stack
-       [:int]               ; Pushes a single result to the :int stack.
+       :int                 ; Pushes a single result to the :int stack.
        0                    ; The instruction opens 0 code blocks.
-       #(vector (+ %1 %2))) ; The function which turns arguments to results.
+       +)                   ; The function which turns arguments to results.
      {:puj.push.instruction/doc  "Pushes the sum of the top 2 ints onto the int stack."})
 
    :int-sub
    (with-meta
-     (u/->SimpleInstruction
-       [:int :int] [:int] 0
-       #(vector (- %1 %2)))
+     (u/->SimpleInstruction [:int :int] :int 0 -)
      {:puj.push.instruction/doc  "Pushes the difference of the top 2 ints onto the int stack."})
 
    :int-mult
    (with-meta
-     (u/->SimpleInstruction
-       [:int :int] [:int] 0
-       #(vector (* %1 %2)))
+     (u/->SimpleInstruction [:int :int] :int 0 *)
      {:puj.push.instruction/doc  "Pushes the product of the top 2 ints onto the int stack."})
 
    :int-inc
    (with-meta
-     (u/->SimpleInstruction
-      [:int] [:int] 0
-      #(vector (inc %)))
+     (u/->SimpleInstruction [:int] :int 0 inc)
      {:puj.push.instruction/doc "Pushes the increment of the top int onto the int stack."})
 
    })

--- a/src/puj/push/instructions/numeric.clj
+++ b/src/puj/push/instructions/numeric.clj
@@ -16,13 +16,20 @@
      (u/->SimpleInstruction
        [:int :int] [:int] 0
        #(vector (- %1 %2)))
-     {:puj.push.instruction/doc  "Pushes the difference of the top 2 into onto the int stack."})
+     {:puj.push.instruction/doc  "Pushes the difference of the top 2 ints onto the int stack."})
 
    :int-mult
    (with-meta
      (u/->SimpleInstruction
        [:int :int] [:int] 0
        #(vector (* %1 %2)))
-     {:puj.push.instruction/doc  "Pushes the product of the top 2 into onto the int stack."})
+     {:puj.push.instruction/doc  "Pushes the product of the top 2 ints onto the int stack."})
+
+   :int-inc
+   (with-meta
+     (u/->SimpleInstruction
+      [:int] [:int] 0
+      #(vector (inc %)))
+     {:puj.push.instruction/doc "Pushes the increment of the top int onto the int stack."})
 
    })

--- a/src/puj/push/interpreter.clj
+++ b/src/puj/push/interpreter.clj
@@ -49,7 +49,7 @@
 (defn run
   "Run a Push program."
   [program inputs stack->type instruction-set & {:keys [validate?]}]
-  (if validate?
+  (when validate?
     (validate-interpretation-context program stack->type instruction-set))
   ; @TODO: Add some kind of flexible metering system.
   (loop [state (-> (state/make-state stack->type)

--- a/src/puj/push/unit.clj
+++ b/src/puj/push/unit.clj
@@ -56,10 +56,7 @@
 (defrecord SimpleInstruction [input-stacks output-stacks opens func]
   PushInstruction
   (open-count [_] opens)
-  (required-stacks [_] (set (concat input-stacks
-                                    (if (coll? output-stacks) ; If output-stacks is not a collection, make it one.
-                                      output-stacks
-                                      [output-stacks]))))
+  (required-stacks [_] (set (concat input-stacks (make-collection output-stacks))))
 
   PushUnit
   (push-unit-type [_] :instruction)

--- a/src/puj/push/unit.clj
+++ b/src/puj/push/unit.clj
@@ -45,6 +45,12 @@
   (open-count [this] "The number of CodeBlocks to open following the instruction. Used by linear genomes.")
   (required-stacks [this] "A set of stack names relevant to the instruction."))
 
+(defn make-collection
+  "If thing is a collection, returns it. Otherwise, returns it in a vector"
+  [thing]
+  (if (coll? thing)
+    thing
+    [thing]))
 
 ; 
 (defrecord SimpleInstruction [input-stacks output-stacks opens func]
@@ -71,13 +77,9 @@
                 (state/pop-from-stacks input-stacks)
                 (state/push-to-stacks
                  ; push-to-stacks expects a collection. If results is not a collection, make it one.
-                 (if (coll? results)
-                   results
-                   [results])
+                 (make-collection results)
                  ; same with output-stacks
-                 (if (coll? output-stacks)
-                   output-stacks
-                   [output-stacks])))))))))
+                 (make-collection output-stacks)))))))))
 
 
 (defrecord StateToStateInstruction [used-stacks opens func]
@@ -103,7 +105,7 @@
     (let [results ((:func this) state)]
       (if (= results :revert)
         state
-        (state/push-to-stacks state results output-stacks)))))
+        (state/push-to-stacks state results (make-collection output-stacks))))))
 
 
 (defrecord ProducesManyOfTypeInstruction [input-stacks output-stack opens func]

--- a/test/puj/push/state_test.clj
+++ b/test/puj/push/state_test.clj
@@ -95,7 +95,17 @@
              {:inputs {}
               :stdout ""
               :untyped (state/queue)
-              :stacks {:int '(10 5 3 1) :string '("y" "z" "a" "b") :exec '()}})))
+              :stacks {:int '(10 5 3 1) :string '("y" "z" "a" "b") :exec '()}}))
+      (is (= (state/push-to-stacks mock-state [11] [:int])
+             {:inputs {}
+              :stdout ""
+              :untyped (state/queue)
+              :stacks {:int '(11 5 3 1) :string '("a" "b") :exec '()}}))
+      (is (= (state/push-to-stacks mock-state ["puj"] [:string])
+             {:inputs {}
+              :stdout ""
+              :untyped (state/queue)
+              :stacks {:int '(5 3 1) :string '("puj" "a" "b") :exec '()}})))
 
     (testing "state size"
       (is (= (state/size mock-state) 5)))

--- a/test/puj/push/unit_test.clj
+++ b/test/puj/push/unit_test.clj
@@ -6,6 +6,11 @@
             [puj.push.type :as t]
             [puj.push.state :as state]))
 
+(deftest make-collection-test
+  (testing "make-collection function"
+    (is (= [5] (u/make-collection 5)))
+    (is (= [4] (u/make-collection [4])))
+    (is (= '(:hello) (u/make-collection '(:hello))))))
 
 (deftest push-literal-test
   (let [int-lit (u/->Literal 5 :int)


### PR DESCRIPTION
Now SimpleInstruction can take a vector of output stacks OR a single keyword output stack.

I assume if no outputs are needed, an empty vector would suffice. But, I'm not sure if this is currently being tested, nor where to put such tests.

Speaking of which, are individual instructions being tested anywhere? I couldn't find tests for them.