### PR TITLE
Refactor of type system. Added vector types.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       LEIN_ROOT: "true"
       JVM_OPTS: -Xmx3200m
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "f2:99:0d:3d:49:06:5c:73:d9:77:2e:1a:0f:30:90:66"
       - checkout
       - run:
           name: save SHA to a file

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
       LEIN_ROOT: "true"
       JVM_OPTS: -Xmx3200m
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "f2:99:0d:3d:49:06:5c:73:d9:77:2e:1a:0f:30:90:66"
       - checkout
       - run:
           name: save SHA to a file

--- a/src/puj/push/interpreter.clj
+++ b/src/puj/push/interpreter.clj
@@ -50,7 +50,7 @@
   "Run a Push program."
   [program inputs type-set instruction-set & {:keys [validate?]}]
   (when validate?
-    (validate-interpretation-context program stack->type instruction-set))
+    (validate-interpretation-context program type-set instruction-set))
   ; @TODO: Add some kind of flexible metering system.
   (loop [state (-> (state/make-state type-set)
                    (state/load-inputs inputs)

--- a/src/puj/push/state.clj
+++ b/src/puj/push/state.clj
@@ -16,12 +16,12 @@
 
 
 (defn make-state
-  "Creates a Push state with one stack per Push type in the given `stack->type`."
-  [stack->type]
-  (typ/validate-stack->type stack->type)
+  "Creates a Push state with one stack per Push type in the given `type-set`."
+  [type-set]
+  (typ/validate-type-set type-set)
   {:inputs {}
    :stdout ""  ; @TODO: Replace with generic IO stream.
-   :stacks (zipmap (conj (keys stack->type) :exec) (repeat (list)))
+   :stacks (zipmap (conj (typ/supported-stacks type-set) :exec) (repeat (list)))
    :untyped (queue)})
 
 

--- a/src/puj/push/type.clj
+++ b/src/puj/push/type.clj
@@ -1,46 +1,104 @@
 (ns puj.push.type
   (:require [clojure.spec.alpha :as spec]
-            [cuerdas.core :as s]))
+            [clojure.set :as set]
+            [puj.util :as u]
+            [cuerdas.core :as string]))
+
+; Specs
+
+(spec/def ::stack-name keyword?)
+(spec/def ::spec spec/spec?)
+(spec/def ::coercer fn?)
+(spec/def ::push-type (spec/keys :req [::stack-name ::spec ::coercer]))
+(spec/def ::type-set (spec/coll-of ::push-type :kind set?))
 
 
+; Scalars
+
+(spec/def ::boolean boolean?)
 (spec/def ::int int?)
+(spec/def ::float float?)
 (spec/def ::string string?)
+(spec/def ::char char?)
 
 
-(spec/def ::stack->type
-  (spec/map-of keyword? spec/spec? :conform-keys true))
+(def core-scalars
+  #{{::stack-name :boolean ::spec (spec/get-spec ::boolean) ::coercer boolean}
+    {::stack-name :int ::spec (spec/get-spec ::int) ::coercer int}
+    {::stack-name :float ::spec (spec/get-spec ::float) ::coercer float}
+    {::stack-name :string ::spec (spec/get-spec ::string) ::coercer str}
+    {::stack-name :char ::spec (spec/get-spec ::char) ::coercer char}})
 
+
+; Vectors
+
+(defn- spec->vec-spec
+  [underlying]
+  (spec/coll-of underlying :kind vector?))
+
+
+(defn make-vector-types
+  [underlying-types]
+  (->> underlying-types
+       (map (fn [push-type]
+              {::stack-name (keyword (str (u/keyword-to-str (::stack-name push-type)) "-vector"))
+               ::spec (spec->vec-spec (::spec push-type))
+               ; @TODO: Heavy use of coercion and vector types will be slow.
+               ::coercer #(vec (map (::coercer push-type) %))}))
+       (into #{})))
+
+
+; Misc.
 
 (def reserved-stack-names
   "A collection of Push stack names than cannot be associated with custom types."
   #{:exec :untyped :stdout :input})
 
 
-(defn validate-stack->type
-  "Raises error if argument is not a valid `stack->type`."
-  [stack->type]
+(defn core-types
+  "Create the core Push types provided by Puj."
+  [& {:keys [vectors?] :or {vectors? true}}]
+  (set/union core-scalars
+             (when vectors? (make-vector-types core-scalars))))
+
+
+(defn validate-type-set
+  "Raises error if argument is not a valid `type-set`."
+  [type-set]
   (do
-    (if (not (spec/valid? ::stack->type stack->type))
-      (throw (AssertionError. (spec/explain-str ::stack->type stack->type))))
-    (assert (not (some reserved-stack-names (keys stack->type)))
-            "Given stack->type uses reserved stack names.")))
+    (when (not (spec/valid? ::type-set type-set))
+      (throw (AssertionError. (spec/explain-str ::type-set type-set))))
+    (assert (not (some reserved-stack-names
+                       (map ::stack-name type-set)))
+            "Provided type-set uses reserved stack names.")))
 
 
-(def base-stack->type
-  "A map of the basic, commonly used, Push stacks and their associated types."
-  {:int (spec/get-spec ::int)
-   :string (spec/get-spec ::string)})
+(defn supported-stacks
+  [type-set]
+  (set (map ::stack-name type-set)))
 
 
+; @TODO: Make this not break for empty vectors.
 (defn stack-for
-  "Given a `stack->type`, return the name of the associated Push stack for the given value."
-  [value stack->type]
-  (let [matches (filter (fn [[ _ spc]] (spec/valid? spc value))
-                        (vec stack->type))]
+  "Given a `type-set`, return the name of the associated Push stack for the given value."
+  [value type-set]
+  (let [matched-types (filter (fn [push-type]
+                                (spec/valid? (::spec push-type) value))
+                              (seq type-set))
+        stack-names (supported-stacks matched-types)]
     (cond
-      (empty? matches) nil
-      (= (count matches) 1) (first (first matches))
+      (empty? stack-names) nil
+      (= (count stack-names) 1) (first stack-names)
       :else
       (throw (AssertionError.
-               (s/format "Ambiguous Push type for value $v."
-                         {:v value}))))))
+               (string/format "Ambiguous Push type for value $v."
+                              {:v value}))))))
+
+(defn valid?
+  [push-type value]
+  (spec/valid? (::spec push-type) value))
+
+
+(defn coerce
+  [push-type value]
+  ((::coercer push-type) value))

--- a/src/puj/push/unit.clj
+++ b/src/puj/push/unit.clj
@@ -33,9 +33,9 @@
 
 
 (defn make-literal
-  "Create a Push literal by recognizing the corresponding Push stack based on the `stack->type`."
-  [value stack->type]
-  (let [s (type/stack-for value stack->type)]
+  "Create a Push literal by recognizing the corresponding Push stack based on the `type-set`."
+  [value type-set]
+  (let [s (type/stack-for value type-set)]
     (if (not (nil? s))
       (Literal. value s))))
 

--- a/test/puj/push/interpreter_test.clj
+++ b/test/puj/push/interpreter_test.clj
@@ -9,7 +9,7 @@
 
 
 (deftest push-interpreter-test
-  (let [stack->type {:int (spec/get-spec ::typ/int)}
+  (let [type-set #{{::typ/stack-name :int ::typ/spec (spec/get-spec ::typ/int) ::typ/coercer int}}
         i-set (i-set/base-instruction-set :name-regex #"int-add|int-sub")]
 
     (testing "simple program execution"
@@ -17,7 +17,7 @@
                       (list (u/->Literal 1 :int) (u/->Literal 2 :int) (:int-add i-set))
                       {}
                       {:i :int})]
-        (is (= (interp/run program {} stack->type i-set :validate? true)
+        (is (= (interp/run program {} type-set i-set :validate? true)
                {::prog/program program
                 ::prog/inputs {}
                 ::prog/outputs {:i 3}}))))
@@ -27,7 +27,7 @@
                       (list (u/->Literal 1 :int) (list (u/->Literal 2 :int) (:int-add i-set)))
                       {}
                       {:i :int})]
-        (is (= (interp/run program {} stack->type i-set :validate? true)
+        (is (= (interp/run program {} type-set i-set :validate? true)
                {::prog/program program
                 ::prog/inputs {}
                 ::prog/outputs {:i 3}}))))

--- a/test/puj/push/state_test.clj
+++ b/test/puj/push/state_test.clj
@@ -6,10 +6,11 @@
 
 
 (deftest push-state-test
-  (let [stack->type {:int (spec/get-spec ::typ/int)}
-        empty-state (state/make-state stack->type)
+  (let [type-set #{{::typ/stack-name :int ::typ/spec (spec/get-spec ::typ/int) ::typ/coercer int}
+                   {::typ/stack-name :string ::typ/spec (spec/get-spec ::typ/string) ::typ/coercer str}}
+        empty-state (state/make-state type-set)
         mock-program {:puj.push.program/code '(7 "Puj")}
-        mock-state (-> (state/make-state typ/base-stack->type)
+        mock-state (-> empty-state
                        (state/set-stack :int '(5 3 1))
                        (state/set-stack :string '("a" "b")))]
 
@@ -22,7 +23,7 @@
              {:inputs {}
               :stdout ""
               :untyped (state/queue)
-              :stacks {:int '() :exec '()}})))
+              :stacks {:int '() :string '() :exec '()}})))
 
     (testing "flush stack"
       (is (= (state/flush-stack mock-state :int)
@@ -70,14 +71,14 @@
              {:inputs {}
               :stdout ""
               :untyped (state/queue)
-              :stacks {:int '() :exec '(7 "Puj")}})))
+              :stacks {:int '() :string '() :exec '(7 "Puj")}})))
 
     (testing "loading inputs"
       (is (= (state/load-inputs empty-state {:i 7 :s "Puj"})
              {:inputs {:i 7 :s "Puj"}
               :stdout ""
               :untyped (state/queue)
-              :stacks {:int '() :exec '()}})))
+              :stacks {:int '() :string '() :exec '()}})))
 
     (testing "observing values from stacks"
       (is (= (state/observe-stacks mock-state [:int :string :int])

--- a/test/puj/push/types_test.clj
+++ b/test/puj/push/types_test.clj
@@ -1,20 +1,51 @@
 (ns puj.push.types-test
   (:require [clojure.test :refer :all]
-            [puj.push.type :as t]
-            [clojure.spec.alpha :as spec]))
+            [puj.push.type :as typ]
+            [clojure.spec.alpha :as spec]
+            [puj.push.type :as type]))
 
 
-(deftest stack->type-test
+(deftest push-type-test
 
-  (testing "should be a map of keywords to specs"
-    (is (spec/valid? ::t/stack->type t/base-stack->type)))
+  (let [int-type {::typ/stack-name :int ::typ/spec (spec/get-spec ::typ/int) ::typ/coercer int}
+        bool-type {::typ/stack-name :boolean ::typ/spec (spec/get-spec ::typ/boolean) ::typ/coercer boolean}]
 
-  (testing "accept a valid stack->type"
-    (t/validate-stack->type t/base-stack->type))
+    (testing "check scalar type"
+      (is (typ/valid? int-type 5))
+      (is (not (typ/valid? int-type true)))
+      (is (not (typ/valid? int-type [5])))
+      (is (typ/valid? bool-type true))
+      (is (not (typ/valid? bool-type 5))))
 
-  (testing "should recall a type by name"
-    (is (= (:int t/base-stack->type) (spec/get-spec ::t/int))))
+    (testing "scalar coercion"
+      (is (= (typ/coerce int-type 1.1) 1))
+      (is (typ/coerce bool-type 50))
+      (is (not (typ/coerce bool-type nil))))
 
-  (testing "can recall a corresponding type name"
-    (is (= (t/stack-for 5 t/base-stack->type) :int))
-    (is (nil? (t/stack-for 1.2 t/base-stack->type)))))
+    (let [int-vec-type (first (typ/make-vector-types #{int-type}))]
+      (testing "check vector type"
+        (is (typ/valid? int-vec-type [3 2 1]))
+        (is (not (typ/valid? int-vec-type [5 "a"])))
+        (is (not (typ/valid? int-vec-type 10))))
+
+      (testing "coerce a vector"
+        (is (= (type/coerce int-vec-type '(1 2 3)) [1 2 3]))
+        (is (= (type/coerce int-vec-type [1 2.5 3]) [1 2 3]))
+        (is (= (type/coerce int-vec-type '(1.2 3.4)) [1 3]))))))
+
+
+(deftest type-set-test
+
+  (let [type-set (typ/core-types)]
+
+    (testing "can validate a type-set"
+      (typ/validate-type-set type-set))
+
+    (testing "prevent reserved stacks from being used"
+      (is (thrown? AssertionError
+                   (typ/validate-type-set #{::type/stack-name :exec ::type/spec any? ::type/coercer identity}))))
+
+    (testing "can produce the corresponding stack name for a value"
+      (is (= (typ/stack-for 5 type-set) :int))
+      (is (= (typ/stack-for 1.2 type-set) :float))
+      (is (= (typ/stack-for ["hi" "bye"] type-set) :string-vector)))))

--- a/test/puj/push/unit_test.clj
+++ b/test/puj/push/unit_test.clj
@@ -3,19 +3,19 @@
             [clojure.spec.alpha :as spec]
             [puj.push.unit :as u]
             [puj.push.state :as st]
-            [puj.push.type :as t]
+            [puj.push.type :as typ]
             [puj.push.state :as state]))
 
 
 (deftest push-literal-test
   (let [int-lit (u/->Literal 5 :int)
         str-lit (u/->Literal "Foo" :string)
-        mock-stack->type {:int    (spec/get-spec ::t/int)
-                          :string (spec/get-spec ::t/string)}
-        empty-state (st/make-state mock-stack->type)]
+        mock-type-set #{{::typ/stack-name :int ::typ/spec (spec/get-spec ::typ/int) ::typ/coercer int}
+                        {::typ/stack-name :string ::typ/spec (spec/get-spec ::typ/string) ::typ/coercer str}}
+        empty-state (st/make-state mock-type-set)]
 
     (testing "literal creation"
-      (is (= (u/make-literal 5 mock-stack->type) int-lit)))
+      (is (= (u/make-literal 5 mock-type-set) int-lit)))
 
     (testing "literal evaluation"
       (is (= (u/eval-push-unit int-lit empty-state)
@@ -31,8 +31,8 @@
 
 
 (deftest push-instruction-test
-  (let [mock-stack->type {:int (spec/get-spec ::t/int)}
-        empty-state (st/make-state mock-stack->type)
+  (let [mock-type-set #{{::typ/stack-name :int ::typ/spec (spec/get-spec ::typ/int) ::typ/coercer int}}
+        empty-state (st/make-state mock-type-set)
         mock-state (st/set-stack empty-state :int '(5 3))]
 
     (testing "simple instructions"
@@ -73,8 +73,8 @@
 
 
 (deftest push-code-block-test
-  (let [mock-stack->type {:int (spec/get-spec ::t/int)}
-        empty-state (st/make-state mock-stack->type)
+  (let [mock-type-set #{{::typ/stack-name :int ::typ/spec (spec/get-spec ::typ/int) ::typ/coercer int}}
+        empty-state (st/make-state mock-type-set)
         lit (u/->Literal 5 :int)
         instr (u/->SimpleInstruction [:int] [:int] 0 #(list (inc %)))
         code-block (list lit instr)]


### PR DESCRIPTION
When considering what it will take to accomplish #4 (full instruction set) I realized that the initial type system I wrote was going to be a paint to work with. 

I removed the concept of a `stack->type` mapping and replaced it with a simple set of push types. Each push type has a `stack-name`. Using this scheme it is trivial to take a set of push types and pass it to a function which will generate a set of corresponding vector types. 

I stopped there, however I think it will be easy to also add more types such as map-types and matrix-types.

I reorganized the file and created some nasty diffs that are hard to read. This PR is probably best reviewed in split view or without the old version.