### PR TITLE
Adds comments to instruction and interpreter tests

### DIFF
--- a/src/puj/push/instruction.clj
+++ b/src/puj/push/instruction.clj
@@ -133,7 +133,7 @@
   (let [results ((::logic-fn instruction) state)]
     (if (= results :revert)
       state
-      (pushstate/push-to-stacks state results (::output-stacks instruction)))))
+      (pushstate/push-to-stacks state (u/ensure-seq results) (::output-stacks instruction)))))
 
 
 (defn emit-many-of-type-instruction

--- a/test/puj/push/instruction_test.clj
+++ b/test/puj/push/instruction_test.clj
@@ -8,47 +8,65 @@
 
 
 (deftest push-instruction-test
-  (let [test-ctx (interp/push-context {:int (:int t/core-scalars)}
-                                      {:simple            (i/simple-instruction :simple [:int :int] :int 0 #(list (+ %1 %2)))
+  ;; Here we will test the evaluation of various instruction types.
+
+  (let [;; We start by creating our push-context that defines the stack types and instruction set.
+        ;; We only need a small number of instructions per instruction type because all instructions of the same kind
+        ;; will follow the same code paths.
+        test-ctx (interp/push-context {:int (:int t/core-scalars)}
+                                      {:add               (i/simple-instruction :add [:int :int] :int 0 +)
+                                       :one-hundred       (i/simple-instruction :one-hundred [] :int 0 (fn [] 100))
                                        :state-to-state    (i/state-to-state-instruction :state-to-state [:int] 0 #(st/flush-stack % :int))
-                                       :takes-state       (i/takes-state-instruction :takes-state :int [] 0 #(list (st/stack-size % :int)))
+                                       :stack-size        (i/takes-state-instruction :stack-size :int [] 0 #(st/stack-size % :int))
                                        :emit-many-of-type (i/emit-many-of-type-instruction :emit-many-of-type [:int :int] :int 0 (fn [x n] (repeat n x)))})
+        ;; An empty state with the correct stacks.
         empty-state (st/make-state (::t/type-library test-ctx))
-        mock-state (st/set-stack empty-state :int '(5 3))
-        get-meta #(i/instruction-meta (get-in test-ctx [::i-set/instruction-set %]))]
+        ;; A simple state with some initial values.
+        mock-state (st/set-stack empty-state :int '(5 3 0))
+        ;; A helper function to pull an instruction-meta from an instruction.
+        get-meta #(i/instruction-meta (get-in test-ctx [::i-set/instruction-set %]))
+        ;; A helper to create push a states with a given map of stacks.
+        state-with (fn [stacks]
+                     {:inputs  {}
+                      :stdout  ""
+                      :untyped (st/queue)
+                      :stacks  stacks})]
 
     (testing "simple instructions"
-      (let [instruction-meta (get-meta :simple)]
-        (is (= (interp/eval-push-unit empty-state instruction-meta test-ctx) empty-state))
-        (is (= (interp/eval-push-unit mock-state instruction-meta test-ctx)
-               {:inputs  {}
-                :stdout  ""
-                :untyped (st/queue)
-                :stacks  {:int '(8) :exec '()}}))))
+      (let [;; Takes 2 args
+            add (get-meta :add)
+            ;; Takes no args
+            one-hundred (get-meta :one-hundred)]
+        ;; The add instruction should no-op on emtpy states/stacks and return an empty state.
+        (is (= (interp/eval-push-unit empty-state add test-ctx) empty-state))
+        ;; The one-hundred instruction requires no args and should push 100.
+        (is (= (interp/eval-push-unit empty-state one-hundred test-ctx)
+               (state-with {:int '(100) :exec '()})))
+        ;; A standard call to the add instruction.
+        (is (= (interp/eval-push-unit mock-state add test-ctx)
+               (state-with {:int '(8 0) :exec '()})))))
 
     (testing "state-to-state instructions"
+      ;; There isn't much to generically test for state-to-state instructions.
+      ;; Each one should be tested individually in core_instructions_tests.clj
       (let [instruction-meta (get-meta :state-to-state)]
         (is (= (interp/eval-push-unit empty-state instruction-meta test-ctx) empty-state))
         (is (= (interp/eval-push-unit mock-state instruction-meta test-ctx) empty-state))))
 
     (testing "takes-state instructions"
-      (let [instruction-meta (get-meta :takes-state)]
-        (is (= (interp/eval-push-unit empty-state instruction-meta test-ctx)
-               {:inputs  {}
-                :stdout  ""
-                :untyped (st/queue)
-                :stacks  {:int '(0) :exec '()}}))
-        (is (= (interp/eval-push-unit mock-state instruction-meta test-ctx)
-               {:inputs  {}
-                :stdout  ""
-                :untyped (st/queue)
-                :stacks  {:int '(2 5 3) :exec '()}}))))
+      ;; There isn't much to generically test for takes-state instructions.
+      ;; Each one should be tested individually in core_instructions_tests.clj
+      (let [stack-size (get-meta :stack-size)]
+        (is (= (interp/eval-push-unit empty-state stack-size test-ctx)
+               (state-with {:int '(0) :exec '()})))
+        (is (= (interp/eval-push-unit mock-state stack-size test-ctx)
+               (state-with {:int '(3 5 3 0) :exec '()})))))
 
     (testing "emit-many-of-type instruction"
       (let [instruction-meta (get-meta :emit-many-of-type)]
+        ;; Emit-many-of-type instructions pop arguments in the same way as simple-instructions.
+        ;; They should no-op on emtpy states/stacks and return an empty state.
         (is (= (interp/eval-push-unit empty-state instruction-meta test-ctx) empty-state))
+        ;; A standard call.
         (is (= (interp/eval-push-unit mock-state instruction-meta test-ctx)
-               {:inputs  {}
-                :stdout  ""
-                :untyped (st/queue)
-                :stacks  {:int '(3 3 3 3 3) :exec '()}}))))))
+               (state-with {:int '(3 3 3 3 3 0) :exec '()})))))))

--- a/test/puj/push/interpreter_test.clj
+++ b/test/puj/push/interpreter_test.clj
@@ -8,10 +8,17 @@
 
 
 (deftest push-interpreter-test
-  (let [ctx (interp/push-context)
+  ;; Tests for the functionality of the push-interpreter.
+  ;; Primarily, we will test the execution of entire push-programs.
+
+  ;; @todo Add tests for the other functions in this namespace.
+
+  (let [;; First we create a push-context (stack types and instruction set). Here we use the default.
+        ctx (interp/push-context)
         instr-set (::i-set/instruction-set ctx)]
 
     (testing "simple program execution"
+      ;; Tests a simple, flat, program that uses a single stack.
       (let [program (prog/make-program
                       (list (u/literal 1 :int) (u/literal 2 :int) (:int-add instr-set))
                       {}
@@ -22,6 +29,7 @@
                (interp/run program {} ctx :validate? true)))))
 
     (testing "nested code block execution"
+      ;; Tests the execution of a program that contains a nested code block.
       (let [program (prog/make-program
                       (list (u/literal 1 :int) (list (u/literal 2 :int) (:int-add instr-set)))
                       {}


### PR DESCRIPTION
@thelmuth I added comments to the tests to instructions and the interpreter. The other tests seemed pretty straightforward if you know the basics of the `clojure.test` library.

The overview at the top of the official API page is pretty good: https://clojure.github.io/clojure/clojure.test-api.html

Let me know if there is anything confusing the undocumented test files... or the documented ones!